### PR TITLE
年度表記に当てられた全てのCSSのIDに正規表現で対応

### DIFF
--- a/src/main/kotlin/app/titech/titechKyomuCore/TitechKyomu.kt
+++ b/src/main/kotlin/app/titech/titechKyomuCore/TitechKyomu.kt
@@ -32,9 +32,7 @@ class TitechKyomu(
 
     internal fun parseReportCheckPage(html: String): List<KyomuCourse> {
         val doc = Jsoup.parse(html)
-        // ...ctl00_lblTerm が2024/10時点、...ctl13_lblTerm が2024/9の東工大時代のCSSのIDです。今後も変更される可能性があります。
-        // #ctl00_ContentPlaceHolder1_ctl00_lblTerm は履修登録状況が一時保存のときのIDです。 今後も変更される可能性があります。
-        val title = doc.select("#ctl00_ContentPlaceHolder1_CheckResult1_ctl08_ctl00_lblTerm, #ctl00_ContentPlaceHolder1_CheckResult1_ctl08_ctl13_lblTerm, #ctl00_ContentPlaceHolder1_ctl00_lblTerm")
+        val title = doc.select("[id$='_lblTerm']") // 科学大変更前後・一時保存の全ケースに対応
             .first()
             ?.html() ?: ""
         val year = "^(\\d+)".toRegex().find(title)?.value?.toIntOrNull() ?: 0


### PR DESCRIPTION
教務Webの申告チェック画面の年度表記に当てられるCSSのIDが
- 東工大時代: ctl00_ContentPlaceHolder1_CheckResult1_ctl08_ctl13_lblTerm
- 科学大: ctl00_ContentPlaceHolder1_CheckResult1_ctl08_ctl00_lblTerm
- 科学大で一時保存状態: ctl00_ContentPlaceHolder1_ctl00_lblTerm

といくつか存在していてエラーの原因となっていたが、表示している年度に割り振られるIDは`lblTerm`を末尾に持つことが共通で、ページ内で他にこの単語は出てこないため、検索を
```swift
doc.css("[id$='_lblTerm']")
```
の形に変更。(AppleOS版と同様)